### PR TITLE
Update ROLoadingImages.netkan

### DIFF
--- a/ROLoadingImages.netkan
+++ b/ROLoadingImages.netkan
@@ -9,5 +9,3 @@ $vref: '#/ckan/ksp-avc'
 x_netkan_force_v: true
 resources:
   repository: https://github.com/KSP-RO/ROLoadingImages
-recommends:
-  - name: RP-1-ExpressInstall


### PR DESCRIPTION
No need to recommend parent's mod, as this mod is unlikely to be installed on its own and creates circular dependencies.